### PR TITLE
Rewrote useDoc 

### DIFF
--- a/pages/communities/[id]/edit.tsx
+++ b/pages/communities/[id]/edit.tsx
@@ -1,0 +1,27 @@
+import Button from '@material-ui/core/Button'
+import Grid from '@material-ui/core/Grid'
+import ArrowBackIcon from '@material-ui/icons/ArrowBack'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+import CommunityEdit from '../../../components/CommunityEdit'
+import Main from '../../../components/Main'
+
+export default function Communities() {
+  const router = useRouter()
+  let id = router.query.id
+  if (Array.isArray(id)) {
+    id = id[0]
+  }
+
+  return (
+    <Main>
+      <Grid container spacing={1}>
+        <Link href="/communities">
+          <Button startIcon={<ArrowBackIcon />}>Back to Communities</Button>
+        </Link>
+      </Grid>
+      <CommunityEdit id={id} />
+    </Main>
+  )
+}

--- a/pages/communities/[id]/index.tsx
+++ b/pages/communities/[id]/index.tsx
@@ -6,11 +6,11 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 
-import CommunityCard from '../../components/CommunityCard'
-import Loading from '../../components/Loading'
-import Main from '../../components/Main'
-import { Data } from '../../services/collections'
-import { useDoc } from '../../services/firestore'
+import CommunityCard from '../../../components/CommunityCard'
+import Loading from '../../../components/Loading'
+import Main from '../../../components/Main'
+import { Entities } from '../../../services/collections'
+import { useDoc } from '../../../services/firestore'
 
 export default function Communities() {
   // require the router to be ready
@@ -18,7 +18,7 @@ export default function Communities() {
   const id = router.query.id as string
 
   // subscribe to the community document
-  const community = useDoc<Data.Community>('communities', id)
+  const community = useDoc(Entities.Community, id)
 
   // edit mode state
   const [editMode, setEditMode] = useState(false)

--- a/pages/communities/index.tsx
+++ b/pages/communities/index.tsx
@@ -3,12 +3,12 @@ import { useRouter } from 'next/router'
 import CommunityCard from '../../components/CommunityCard'
 import CommunityGrid from '../../components/CommunityGrid'
 import Main from '../../components/Main'
-import { Data } from '../../services/collections'
+import { Entities } from '../../services/collections'
 import { collection, useQuery } from '../../services/firestore'
 
 export default function Communities() {
   const router = useRouter()
-  const query = collection<Data.Community>('communities').limit(10)
+  const query = collection(Entities.Community).limit(10)
   const docs = useQuery(query) || []
 
   return (

--- a/services/collections.ts
+++ b/services/collections.ts
@@ -7,8 +7,24 @@ export namespace Data {
 
   export interface Community {
     name: string
-    description: string
-    image: string
+    details: {
+      description?: string
+      image?: string
+    }
   }
 
+}
+
+export interface Entity<T> {
+  collection: string
+}
+
+export namespace Entities {
+  export const Event: Entity<Data.Event> = {
+    collection: 'event'
+  }
+
+  export const Community: Entity<Data.Community> = {
+    collection: 'communities'
+  }
 }

--- a/services/collections.ts
+++ b/services/collections.ts
@@ -7,10 +7,8 @@ export namespace Data {
 
   export interface Community {
     name: string
-    details: {
-      description?: string
-      image?: string
-    }
+    description?: string
+    image?: string
   }
 
 }

--- a/services/firestore.ts
+++ b/services/firestore.ts
@@ -1,19 +1,20 @@
 import { useEffect, useState } from 'react'
 
+import { Entity } from './collections'
 import firebase from './firebase'
 
 // get a typed firestore collection
-export function collection<T>(name: string) {
-  return firebase.firestore().collection(name) as firebase.firestore.CollectionReference<T>
+export function collection<T>(entity: Entity<T>) {
+  return firebase.firestore().collection(entity.collection) as firebase.firestore.CollectionReference<T>
 }
 
 // subscribe to a firestore document in a react component
-export function useDoc<T = any>(collectionName: string, id: string): firebase.firestore.DocumentSnapshot<T> | null {
+export function useDoc<T = any>(entity: Entity<T>, id: string): firebase.firestore.DocumentSnapshot<T> | null {
   const [doc, setDoc] = useState(null)
 
   useEffect(() => {
     if (!id) return
-    return collection<T>(collectionName).doc(id).onSnapshot(doc => setDoc(doc))
+    return collection<T>(entity).doc(id).onSnapshot(doc => setDoc(doc))
   }, [id])
 
   return doc


### PR DESCRIPTION
This removes the need to type the collection name whenever collection() or useDoc() are used. 