### PR TITLE
Elaborate on setup instructions

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,0 @@
-{
-  "projects": {
-    "default": "evenagement"
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,12 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# local configuration files
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
+.firebaserc
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -5,46 +5,46 @@ Evenagement is a web application to manage communities.
 
 ## Setup
 
+### Toolchain
+
 1. Install [pnpm](https://pnpm.js.org): `npm i -g pnpm`
 2. Install [firebase-tools](https://firebase.google.com/docs/cli): `pnpm i -g firebase-tools`
-3. Configure environment (see below)
-
-### Production Build
-
-1. Install packages: `pnpm i --frozen-lockfile`
-2. Build: `pnpm build`
-3. Start: `pnpm start`
-4. Open [http://localhost:3000/]
 
 ### Development
 
+We use the [Firebase Emulator](https://firebase.google.com/docs/emulator-suite) for development and testing. (Note that you still need to configure a real Firebase Project in the environment, as [shown below](#environment).)
+
+1. Ensure `NEXT_PUBLIC_USE_FIREBASE_EMULATOR=1` is set in [`.env.local`](./.env.local)
+2. Start emulator: `pnpm run emulator`
+
+With the emulator running, you can start the development server in parallel:
+
 1. Install packages: `pnpm i`
 2. Start development server: `pnpm run dev`
-3. Open [http://localhost:3000/]
-
-### Development with Firebase Emulator
-
-We use the [Firebase Emulator](https://firebase.google.com/docs/emulator-suite) when developing or testing the app.
-
-1. Add `NEXT_PUBLIC_USE_FIREBASE_EMULATOR=1` to `.env.local`
-2. Start emulator: `pnpm run emulator`
-3. Start development as described above
+3. Open http://localhost:3000/
 
 ### Storybook
 
 We use [Storybook](https://storybook.js.org) to test and showcase our components.
 
-1. Run `pnpm run storybook`
-2. Open [http://localhost:9009]
+1. Start Storybook: `pnpm run storybook`
+2. Open http://localhost:9009
 
 Edit `[component].stories.tsx` to configure the options of a component
 
+### Production Build
 
-## Configuration
+1. Configure the environment (see [below](#environment))
+2. Install packages: `pnpm i --frozen-lockfile`
+3. Build: `pnpm build`
+4. Start: `pnpm start`
+5. Open http://localhost:3000/
 
-Environment variables can be se in `.env.local`.
+### Environment
 
-Firebase Configuration:
+Environment variables can be se in [`.env.local`](./.env.local).
+
+[**Firebase Configuration:**](https://support.google.com/firebase/answer/7015592)
 
 ```
 NEXT_PUBLIC_FIREBASE_APIKEY=
@@ -56,14 +56,16 @@ NEXT_PUBLIC_FIREBASE_APPID=
 NEXT_PUBLIC_FIREBASE_MEASUREMENTID=
 ```
 
-Development Configuration:
+Also set your project ID in [`.firebaserc`](./.firebaserc).
+
+**Development Configuration:**
 
 ```
-NEXT_PUBLIC_USE_FIREBASE_EMULATOR=1  #enable the emulator
-NEXT_PUBLIC_DEBUG=1  #enable debug support (sets window.firebase)
+NEXT_PUBLIC_USE_FIREBASE_EMULATOR=1  # enables the emulator
+NEXT_PUBLIC_DEBUG=1  # enables debug support by setting window.firebase
 ```
 
-Sendgrid Configuration:
+**Sendgrid Configuration:**
 
 ```
 SENDGRID_API_KEY=

--- a/README.md
+++ b/README.md
@@ -56,7 +56,15 @@ NEXT_PUBLIC_FIREBASE_APPID=
 NEXT_PUBLIC_FIREBASE_MEASUREMENTID=
 ```
 
-Also set your project ID in [`.firebaserc`](./.firebaserc).
+Also set your project ID in [`.firebaserc`](./.firebaserc):
+
+```
+{
+  "projects": {
+    "default": "<your Firebase project ID>"
+  }
+}
+```
 
 **Development Configuration:**
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Evenagement is a web application to manage communities.
 
 ### Development
 
-We use the [Firebase Emulator](https://firebase.google.com/docs/emulator-suite) for development and testing. (Note that you still need to configure a real Firebase Project in the environment, as [shown below](#environment).)
+We use the [Firebase Emulator](https://firebase.google.com/docs/emulator-suite) for development and testing. (Note that you still need to configure a real Firebase project in the environment, as [shown below](#environment).)
 
 1. Ensure `NEXT_PUBLIC_USE_FIREBASE_EMULATOR=1` is set in [`.env.local`](./.env.local)
 2. Start emulator: `pnpm run emulator`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "test": "tsc --project .; eslint . --ext .js,.jsx,.ts,.tsx",
+    "test": "tsc --project . && eslint . --ext .js,.jsx,.ts,.tsx",
     "prepare": "husky install",
     "dev": "next dev",
     "dev-emulator": "concurrently -k \"npm:dev\" \"npm:emulator\"",


### PR DESCRIPTION
There were a few details missing from the setup guide, like the fact that you need to have a real Firebase project even though you are using the emulators.

As a consequence, you also need to put your own project ID into `.firebaserc`, therefore this PR makes Git ignore that file and adds instructions on how to manually set it up.